### PR TITLE
Add support for Laravel 5.8 for version v5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,12 +19,12 @@
     ],
     "require": {
         "php": "^7.1",
-        "illuminate/console": "~5.5.0|~5.6.0|~5.7.0",
-        "illuminate/contracts": "~5.5.0|~5.6.0|~5.7.0",
-        "illuminate/events": "~5.5.0|~5.6.0|~5.7.0",
-        "illuminate/filesystem": "~5.5.0|~5.6.0|~5.7.0",
-        "illuminate/support": "~5.5.0|~5.6.0|~5.7.0",
-        "illuminate/notifications": "~5.5.0|~5.6.0|~5.7.0",
+        "illuminate/console": "~5.5.0|~5.6.0|~5.7.0|~5.8.0",
+        "illuminate/contracts": "~5.5.0|~5.6.0|~5.7.0|~5.8.0",
+        "illuminate/events": "~5.5.0|~5.6.0|~5.7.0|~5.8.0",
+        "illuminate/filesystem": "~5.5.0|~5.6.0|~5.7.0|~5.8.0",
+        "illuminate/support": "~5.5.0|~5.6.0|~5.7.0|~5.8.0",
+        "illuminate/notifications": "~5.5.0|~5.6.0|~5.7.0|~5.8.0",
         "league/flysystem": "^1.0.27",
         "spatie/db-dumper": "^2.11.1",
         "spatie/temporary-directory": "^1.1",
@@ -32,7 +32,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^7.3",
-        "orchestra/testbench" : "~3.5.0|~3.6.0|~3.7.0",
+        "orchestra/testbench" : "~3.5.0|~3.6.0|~3.7.0|~3.8.0",
         "mockery/mockery": "^1.0"
     },
     "autoload": {


### PR DESCRIPTION
For those of us who still work on PHP 7.1.* but want to use Laravel 5.8 :)